### PR TITLE
Fix OIDC logout action provider canHandle check

### DIFF
--- a/platform/security/handler/security-handler-oidc/src/main/java/org/codice/ddf/security/handler/oidc/OidcLogoutActionProvider.java
+++ b/platform/security/handler/security-handler-oidc/src/main/java/org/codice/ddf/security/handler/oidc/OidcLogoutActionProvider.java
@@ -17,6 +17,8 @@ import ddf.action.Action;
 import ddf.action.ActionProvider;
 import ddf.action.impl.ActionImpl;
 import ddf.security.SecurityConstants;
+import ddf.security.Subject;
+import ddf.security.SubjectUtils;
 import ddf.security.assertion.SecurityAssertion;
 import ddf.security.assertion.jwt.impl.SecurityAssertionJwt;
 import ddf.security.common.SecurityTokenHolder;
@@ -141,14 +143,12 @@ public class OidcLogoutActionProvider implements ActionProvider {
       return false;
     }
 
-    HttpServletRequest request = (HttpServletRequest) ((Map) subjectMap).get("http_request");
-    HttpServletResponse response = (HttpServletResponse) ((Map) subjectMap).get("http_response");
-
-    if (request == null || response == null) {
+    Object subject = ((Map) subjectMap).get(SecurityConstants.SECURITY_SUBJECT);
+    if (!(subject instanceof Subject)) {
       return false;
     }
 
-    Object credentials = ((Map) subjectMap).get(SecurityConstants.SECURITY_SUBJECT);
-    return credentials instanceof OidcCredentials;
+    String type = SubjectUtils.getType((org.apache.shiro.subject.Subject) subject);
+    return type != null && type.equals(SecurityAssertionJwt.JWT_TOKEN_TYPE);
   }
 }

--- a/platform/security/handler/security-handler-oidc/src/test/java/org/codice/ddf/security/oidc/client/OidcLogoutActionProviderTest.java
+++ b/platform/security/handler/security-handler-oidc/src/test/java/org/codice/ddf/security/oidc/client/OidcLogoutActionProviderTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableMap;
 import ddf.action.Action;
 import ddf.security.SecurityConstants;
+import ddf.security.Subject;
 import ddf.security.assertion.SecurityAssertion;
 import ddf.security.assertion.jwt.impl.SecurityAssertionJwt;
 import ddf.security.common.SecurityTokenHolder;
@@ -68,15 +69,17 @@ public class OidcLogoutActionProviderTest {
     HttpServletRequest request = mock(HttpServletRequest.class);
     HttpServletResponse response = mock(HttpServletResponse.class);
     HttpSession session = mock(HttpSession.class);
+    Subject subject = mock(Subject.class);
     SecurityTokenHolder tokenHolder = mock(SecurityTokenHolder.class);
     SimplePrincipalCollection principalCollection = new SimplePrincipalCollection();
+    SecurityAssertion securityAssertion = mock(SecurityAssertion.class);
     OidcCredentials credentials = mock(OidcCredentials.class);
 
-    SecurityAssertion securityAssertion = mock(SecurityAssertion.class);
     when(securityAssertion.getToken()).thenReturn(credentials);
     when(securityAssertion.getTokenType()).thenReturn(SecurityAssertionJwt.JWT_TOKEN_TYPE);
+    when(subject.getPrincipals()).thenReturn(principalCollection);
     when(tokenHolder.getPrincipals()).thenReturn(principalCollection);
-    principalCollection.add(securityAssertion, "default");
+    principalCollection.add(securityAssertion, "oidc");
     when(session.getAttribute(SecurityConstants.SECURITY_TOKEN_KEY)).thenReturn(tokenHolder);
     when(request.getSession(false)).thenReturn(session);
 
@@ -84,7 +87,7 @@ public class OidcLogoutActionProviderTest {
         oidcLogoutActionProvider.getAction(
             ImmutableMap.of(
                 SecurityConstants.SECURITY_SUBJECT,
-                credentials,
+                subject,
                 "http_request",
                 request,
                 "http_response",


### PR DESCRIPTION
This fixes OIDC logout. The action provider canHandle check always returned false, so the action provider never returned an action.