### PR TITLE
Disable internal IdP guest login

### DIFF
--- a/platform/security/idp/security-idp-server/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/idp/security-idp-server/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -62,7 +62,7 @@
         <property name="tokenFactory" ref="tokenFactory" />
         <property name="strictSignature" value="true" />
         <property name="strictRelayState" value="true" />
-        <property name="guestAccess" value="true" />
+        <property name="guestAccess" value="false" />
         <property name="logoutMessage" ref="logoutMessage" />
         <property name="logoutStates" ref="logoutStates" />
         <property name="spMetadata">

--- a/platform/security/idp/security-idp-server/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/platform/security/idp/security-idp-server/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -34,10 +34,6 @@
             default="30"
             description="Sets the cookie expiration time for single sign on. This value should match the lifetime of SAML assertions"/>
 
-        <AD name="Allow Guest Access" id="guestAccess" required="false" type="Boolean"
-            default="true"
-            description="Toggle whether or not to allow Guest access. The default is 'true'."/>
-
     </OCD>
 
     <Designate pid="org.codice.ddf.security.idp.server.IdpEndpoint">


### PR DESCRIPTION
Change the default in blueprint and remove the metatype attribute so users can't enable guest login. 

Note: This is just a temporary solution since the STS can't generate SAML assertions for guest anymore (the BST validator was removed). When the STS is removed and the SAML generation code is moved to the IdP endpoint, we should be able to support guest access again.