### PR TITLE
Swap SSO config in UI and lazy load OidcConfiguration

### DIFF
--- a/features/admin/src/main/feature/feature.xml
+++ b/features/admin/src/main/feature/feature.xml
@@ -177,7 +177,6 @@
         <feature>cxf-jaxws</feature>
         <feature>cxf-jaxrs</feature>
         <feature>security-handler-api</feature>
-        <feature>oidc-dependencies</feature>
 
         <bundle>mvn:ddf.admin.core/admin-core-migration-commands/${project.version}</bundle>
     </feature>

--- a/platform/security/handler/security-handler-api/src/main/java/org/codice/ddf/security/handler/api/OidcHandlerConfiguration.java
+++ b/platform/security/handler/security-handler-api/src/main/java/org/codice/ddf/security/handler/api/OidcHandlerConfiguration.java
@@ -16,16 +16,14 @@ package org.codice.ddf.security.handler.api;
 import org.pac4j.oidc.client.OidcClient;
 import org.pac4j.oidc.config.OidcConfiguration;
 import org.pac4j.oidc.logout.OidcLogoutActionBuilder;
-import org.pac4j.oidc.profile.creator.OidcProfileCreator;
 
 public interface OidcHandlerConfiguration {
+
   OidcConfiguration getOidcConfiguration();
 
   OidcClient getOidcClient();
 
-  OidcLogoutActionBuilder getLogoutActionBuilder();
+  OidcLogoutActionBuilder getOidcLogoutActionBuilder();
 
-  OidcProfileCreator getOidcProfileCreator();
-
-  boolean isInitialized();
+  void testConnection();
 }

--- a/platform/security/handler/security-handler-oidc/pom.xml
+++ b/platform/security/handler/security-handler-oidc/pom.xml
@@ -218,17 +218,17 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.19</minimum>
+                                            <minimum>0.66</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.11</minimum>
+                                            <minimum>0.75</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.14</minimum>
+                                            <minimum>0.58</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/platform/security/handler/security-handler-oidc/src/main/java/org/codice/ddf/security/handler/oidc/OidcLogoutActionProvider.java
+++ b/platform/security/handler/security-handler-oidc/src/main/java/org/codice/ddf/security/handler/oidc/OidcLogoutActionProvider.java
@@ -103,7 +103,8 @@ public class OidcLogoutActionProvider implements ActionProvider {
         throw new IllegalStateException("Unable to determine OIDC profile for logout");
       }
 
-      OidcLogoutActionBuilder logoutActionBuilder = handlerConfiguration.getLogoutActionBuilder();
+      OidcLogoutActionBuilder logoutActionBuilder =
+          handlerConfiguration.getOidcLogoutActionBuilder();
       logoutActionBuilder.setAjaxRequestResolver(
           new DefaultAjaxRequestResolver() {
             @Override

--- a/platform/security/handler/security-handler-oidc/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/handler/security-handler-oidc/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -19,25 +19,50 @@
   xsi:schemaLocation="
   http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd">
 
+
+    <!--
+        cm:managed-properties inline in the bean didn't persist configuration across restarts.
+        Using cm:property-placeholder instead
+      -->
+    <cm:property-placeholder persistent-id="org.codice.ddf.security.handler.api.OidcHandlerConfiguration" update-strategy="reload">
+        <cm:default-properties>
+            <cm:property name="properties">
+                <map>
+                    <entry key="idpType" value="Keycloak"/>
+                    <entry key="clientId" value="ddf-client"/>
+                    <entry key="realm" value="master"/>
+                    <entry key="secret" value="secret"/>
+                    <entry key="discoveryUri"
+                      value="http://localhost:8080/auth/realms/master/.well-known/openid-configuration"/>
+                    <entry key="baseUri" value="http://localhost:8080/auth"/>
+                    <entry key="logoutUri" value="http://localhost:8080/auth/realms/master/protocol/openid-connect/logout"/>
+                    <entry key="scope" value="openid profile email resource.read"/>
+                    <entry key="useNonce">
+                        <value type="java.lang.Boolean">true</value>
+                    </entry>
+                    <entry key="responseType" value="code"/>
+                    <entry key="responseMode" value="form_post"/>
+                </map>
+            </cm:property>
+        </cm:default-properties>
+    </cm:property-placeholder>
+
     <bean id="oidcConfiguration" class="org.codice.ddf.security.handler.oidc.OidcHandlerConfigurationImpl">
-        <cm:managed-properties persistent-id="org.codice.ddf.security.handler.api.OidcHandlerConfiguration"
-          update-strategy="component-managed" update-method="update"/>
         <property name="properties">
             <map>
-                <entry key="idpType" value="Keycloak"/>
-                <entry key="clientId" value="ddf-client"/>
-                <entry key="realm" value="master"/>
-                <entry key="secret" value="secret"/>
-                <entry key="discoveryUri"
-                  value="http://localhost:8080/auth/realms/master/.well-known/openid-configuration"/>
-                <entry key="baseUri" value="http://localhost:8080/auth"/>
-                <entry key="logoutUri" value="http://localhost:8080/auth/realms/master/protocol/openid-connect/logout"/>
-                <entry key="scope" value="openid profile email resource.read"/>
+                <entry key="idpType" value="${idpType}"/>
+                <entry key="clientId" value="${clientId}"/>
+                <entry key="realm" value="${realm}"/>
+                <entry key="secret" value="${secret}"/>
+                <entry key="discoveryUri" value="${discoveryUri}"/>
+                <entry key="baseUri" value="${baseUri}"/>
+                <entry key="logoutUri" value="${logoutUri}"/>
+                <entry key="scope" value="${scope}"/>
                 <entry key="useNonce">
-                    <value type="java.lang.Boolean">true</value>
+                    <value type="java.lang.Boolean">${useNonce}</value>
                 </entry>
-                <entry key="responseType" value="code"/>
-                <entry key="responseMode" value="form_post"/>
+                <entry key="responseType" value="${responseType}"/>
+                <entry key="responseMode" value="${responseMode}"/>
             </map>
         </property>
     </bean>

--- a/platform/security/handler/security-handler-oidc/src/test/java/org/codice/ddf/security/handler/oidc/OidcHandlerConfigurationImplTest.java
+++ b/platform/security/handler/security-handler-oidc/src/test/java/org/codice/ddf/security/handler/oidc/OidcHandlerConfigurationImplTest.java
@@ -15,85 +15,86 @@ package org.codice.ddf.security.handler.oidc;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.pac4j.oidc.client.AzureAdClient;
+import org.pac4j.oidc.client.GoogleOidcClient;
+import org.pac4j.oidc.client.KeycloakOidcClient;
+import org.pac4j.oidc.client.OidcClient;
+import org.pac4j.oidc.config.AzureAdOidcConfiguration;
+import org.pac4j.oidc.config.KeycloakOidcConfiguration;
+import org.pac4j.oidc.config.OidcConfiguration;
 
 @RunWith(MockitoJUnitRunner.class)
 public class OidcHandlerConfigurationImplTest {
-  private static Map<String, Object> emptyProperties;
-  private static Map<String, Object> validProperties;
-  private static Map<String, Object> invalidProperties;
 
-  private OidcHandlerConfigurationImpl handlerConfiguration;
+  private static OidcHandlerConfigurationImpl handlerConfiguration;
 
   @BeforeClass
   public static void setupClass() {
-    emptyProperties = new HashMap<>();
-
-    validProperties = new HashMap<>();
-    validProperties.put(OidcHandlerConfigurationImpl.IDP_TYPE, "generic");
-    validProperties.put(OidcHandlerConfigurationImpl.CLIENT_ID, "generic-client");
-    validProperties.put(OidcHandlerConfigurationImpl.REALM, "master");
-    validProperties.put(OidcHandlerConfigurationImpl.SECRET, "changeit");
-    validProperties.put(OidcHandlerConfigurationImpl.DISCOVERY_URI, "https://discovery/uri");
-    validProperties.put(OidcHandlerConfigurationImpl.BASE_URI, "https://base/uri");
-    validProperties.put(OidcHandlerConfigurationImpl.SCOPE, "openid profile email");
-    validProperties.put(OidcHandlerConfigurationImpl.USE_NONCE, false);
-    validProperties.put(OidcHandlerConfigurationImpl.RESPONSE_TYPE, "code");
-    validProperties.put(OidcHandlerConfigurationImpl.RESPONSE_MODE, "form_post");
-    validProperties.put(OidcHandlerConfigurationImpl.LOGOUT_URI, "https://logout/uri");
-
-    invalidProperties = new HashMap<>();
-    invalidProperties.put(OidcHandlerConfigurationImpl.IDP_TYPE, "invalid idpType");
-    invalidProperties.put(OidcHandlerConfigurationImpl.CLIENT_ID, "invalid clientId");
-    invalidProperties.put(OidcHandlerConfigurationImpl.REALM, "invalid realm");
-    invalidProperties.put(OidcHandlerConfigurationImpl.SECRET, "invalid secret");
-    invalidProperties.put(OidcHandlerConfigurationImpl.DISCOVERY_URI, "invalid discoveryUri");
-    invalidProperties.put(OidcHandlerConfigurationImpl.BASE_URI, "invalid baseUri");
-    invalidProperties.put(OidcHandlerConfigurationImpl.SCOPE, "invalid scope");
-    invalidProperties.put(OidcHandlerConfigurationImpl.USE_NONCE, "invalid useNonce");
-    invalidProperties.put(OidcHandlerConfigurationImpl.RESPONSE_TYPE, "invalid responseType");
-    invalidProperties.put(OidcHandlerConfigurationImpl.RESPONSE_MODE, "invalid responseMode");
-    invalidProperties.put(OidcHandlerConfigurationImpl.LOGOUT_URI, "invalid logoutUri");
+    handlerConfiguration = new OidcHandlerConfigurationImpl();
   }
 
   @Test
-  public void constructWithNull() {
-    handlerConfiguration = new OidcHandlerConfigurationImpl();
-    handlerConfiguration.update(null);
-
-    assertThat(handlerConfiguration.isInitialized(), is(false));
+  public void testUpdateNullProperties() {
+    handlerConfiguration.setProperties(null);
   }
 
   @Test
-  public void constructWithEmptyProperties() {
-    handlerConfiguration = new OidcHandlerConfigurationImpl();
-    handlerConfiguration.update(emptyProperties);
-
-    assertThat(handlerConfiguration.isInitialized(), is(false));
+  public void testUpdateEmptyProperties() {
+    Map<String, Object> properties = spy(new HashMap<>());
+    handlerConfiguration.setProperties(properties);
+    verify(properties, never()).getOrDefault(anyString(), any());
   }
 
-  @Test(expected = ClassCastException.class)
-  public void constructWithInvalidProperties() {
-    handlerConfiguration = new OidcHandlerConfigurationImpl();
-    handlerConfiguration.update(invalidProperties);
-
-    assertThat(handlerConfiguration.isInitialized(), is(false));
-  }
-
-  /* currently does not initialize due to a backend http call to the DiscoveryUri failing */
-  @Ignore
   @Test
-  public void constructWithValidProperties() {
-    handlerConfiguration = new OidcHandlerConfigurationImpl();
-    handlerConfiguration.update(validProperties);
+  public void testCreateOidcConfigurationKeycloak() {
+    OidcConfiguration oidcConfiguration =
+        handlerConfiguration.createOidcConfiguration("Keycloak", "master", "https://base/uri");
+    assertTrue(oidcConfiguration instanceof KeycloakOidcConfiguration);
+    assertThat(((KeycloakOidcConfiguration) oidcConfiguration).getRealm(), is("master"));
+    assertThat(
+        ((KeycloakOidcConfiguration) oidcConfiguration).getBaseUri(), is("https://base/uri"));
+  }
 
-    assertThat(handlerConfiguration.isInitialized(), is(false));
+  @Test
+  public void testCreateOidcConfigurationAzure() {
+    OidcConfiguration oidcConfiguration =
+        handlerConfiguration.createOidcConfiguration("Azure", "master", "https://base/uri");
+    assertTrue(oidcConfiguration instanceof AzureAdOidcConfiguration);
+    assertThat(((AzureAdOidcConfiguration) oidcConfiguration).getTenant(), is("master"));
+  }
+
+  @Test
+  public void testCreateOidcClientKeycloak() {
+    OidcConfiguration oidcConfiguration = mock(KeycloakOidcConfiguration.class);
+    OidcClient oidcClient = handlerConfiguration.createOidcClient("Keycloak", oidcConfiguration);
+    assertTrue(oidcClient instanceof KeycloakOidcClient);
+  }
+
+  @Test
+  public void testCreateOidcClientAzure() {
+    OidcConfiguration oidcConfiguration = mock(AzureAdOidcConfiguration.class);
+    OidcClient oidcClient = handlerConfiguration.createOidcClient("Azure", oidcConfiguration);
+    assertTrue(oidcClient instanceof AzureAdClient);
+  }
+
+  @Test
+  public void testCreateOidcClientGoogle() {
+    OidcConfiguration oidcConfiguration = mock(OidcConfiguration.class);
+    OidcClient oidcClient = handlerConfiguration.createOidcClient("Google", oidcConfiguration);
+    assertTrue(oidcClient instanceof GoogleOidcClient);
   }
 }

--- a/platform/security/handler/security-handler-oidc/src/test/java/org/codice/ddf/security/handler/oidc/OidcHandlerTest.java
+++ b/platform/security/handler/security-handler-oidc/src/test/java/org/codice/ddf/security/handler/oidc/OidcHandlerTest.java
@@ -65,7 +65,6 @@ public class OidcHandlerTest {
   @Mock private HttpServletResponse mockResponse;
   @Mock private HttpSession mockSession;
 
-  private OidcClient oidcClient;
   private Map<String, String[]> parameterMap = new HashMap<>();
 
   @BeforeClass
@@ -100,9 +99,8 @@ public class OidcHandlerTest {
     mockOidcClient = new MockOidcClient();
 
     // oidc configuration
-    when(mockConfiguration.getOidcClient()).thenReturn(mockOidcClient);
     when(mockConfiguration.getOidcConfiguration()).thenReturn(mockOidcConfiguration);
-    when(mockConfiguration.isInitialized()).thenReturn(true);
+    when(mockConfiguration.getOidcClient()).thenReturn(mockOidcClient);
 
     // session
     when(mockSession.getAttribute("oidcStateAttribute")).thenReturn(state);
@@ -130,7 +128,6 @@ public class OidcHandlerTest {
   @Test
   public void constructWithEmptyConfiguration() {
     OidcHandlerConfigurationImpl emptyConfiguration = new OidcHandlerConfigurationImpl();
-    emptyConfiguration.update(new HashMap<>());
     handler = new OidcHandler(emptyConfiguration);
 
     assertThat(handler.getConfiguration(), is(emptyConfiguration));
@@ -144,15 +141,6 @@ public class OidcHandlerTest {
 
     verify(mockResponse, times(1)).setStatus(HttpServletResponse.SC_OK);
     verify(mockResponse, times(1)).flushBuffer();
-    assertThat(result.getStatus(), is(Status.NO_ACTION));
-  }
-
-  @Test
-  public void getNormalizedTokenNonInitializedConfiguration() throws Exception {
-    when(mockConfiguration.isInitialized()).thenReturn(false);
-    handler = new OidcHandler(mockConfiguration);
-    result = handler.getNormalizedToken(mockRequest, mockResponse, null, false);
-
     assertThat(result.getStatus(), is(Status.NO_ACTION));
   }
 
@@ -231,6 +219,11 @@ public class OidcHandlerTest {
     @Override
     public String computeFinalCallbackUrl(final WebContext context) {
       return "https://final.callback.url";
+    }
+
+    @Override
+    public OidcConfiguration getConfiguration() {
+      return mockOidcConfiguration;
     }
   }
 }

--- a/platform/security/handler/security-handler-oidc/src/test/java/org/codice/ddf/security/handler/oidc/OidcLogoutActionProviderTest.java
+++ b/platform/security/handler/security-handler-oidc/src/test/java/org/codice/ddf/security/handler/oidc/OidcLogoutActionProviderTest.java
@@ -37,7 +37,6 @@ import org.pac4j.core.redirect.RedirectAction;
 import org.pac4j.oidc.credentials.OidcCredentials;
 import org.pac4j.oidc.logout.OidcLogoutActionBuilder;
 import org.pac4j.oidc.profile.OidcProfile;
-import org.pac4j.oidc.profile.creator.OidcProfileCreator;
 
 public class OidcLogoutActionProviderTest {
 
@@ -47,18 +46,13 @@ public class OidcLogoutActionProviderTest {
 
   @Before
   public void setup() {
-    OidcProfileCreator oidcProfileCreator = mock(OidcProfileCreator.class);
-    OidcProfile oidcProfile = mock(OidcProfile.class);
-    when(oidcProfileCreator.create(any(), any())).thenReturn(oidcProfile);
-
     OidcLogoutActionBuilder oidcLogoutActionBuilder = mock(OidcLogoutActionBuilder.class);
     RedirectAction redirectAction = mock(RedirectAction.class);
     when(redirectAction.getLocation()).thenReturn(LOCATION);
     when(oidcLogoutActionBuilder.getLogoutAction(any(), any(), any())).thenReturn(redirectAction);
 
     OidcHandlerConfiguration handlerConfiguration = mock(OidcHandlerConfiguration.class);
-    when(handlerConfiguration.getLogoutActionBuilder()).thenReturn(oidcLogoutActionBuilder);
-    when(handlerConfiguration.getOidcProfileCreator()).thenReturn(oidcProfileCreator);
+    when(handlerConfiguration.getOidcLogoutActionBuilder()).thenReturn(oidcLogoutActionBuilder);
 
     oidcLogoutActionProvider = new OidcLogoutActionProvider(handlerConfiguration);
   }

--- a/platform/security/security-oidc-realm/src/main/java/org/codice/ddf/security/oidc/realm/OidcRealm.java
+++ b/platform/security/security-oidc-realm/src/main/java/org/codice/ddf/security/oidc/realm/OidcRealm.java
@@ -28,6 +28,8 @@ import org.codice.ddf.security.handler.api.OidcAuthenticationToken;
 import org.codice.ddf.security.handler.api.OidcHandlerConfiguration;
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.exception.TechnicalException;
+import org.pac4j.oidc.client.OidcClient;
+import org.pac4j.oidc.config.OidcConfiguration;
 import org.pac4j.oidc.credentials.OidcCredentials;
 import org.pac4j.oidc.credentials.authenticator.OidcAuthenticator;
 import org.pac4j.oidc.profile.OidcProfile;
@@ -81,11 +83,11 @@ public class OidcRealm extends AuthenticatingRealm {
     // token is guaranteed to be of type OidcAuthenticationToken by the supports() method
     OidcAuthenticationToken oidcAuthenticationToken = (OidcAuthenticationToken) authenticationToken;
     OidcCredentials credentials = (OidcCredentials) oidcAuthenticationToken.getCredentials();
-    OIDCProviderMetadata oidcProviderMetadata =
-        oidcHandlerConfiguration.getOidcConfiguration().findProviderMetadata();
+    OidcConfiguration oidcConfiguration = oidcHandlerConfiguration.getOidcConfiguration();
+    OidcClient oidcClient = oidcHandlerConfiguration.getOidcClient();
+    OIDCProviderMetadata oidcProviderMetadata = oidcConfiguration.findProviderMetadata();
     OidcTokenValidator oidcTokenValidator =
-        new OidcTokenValidator(
-            oidcHandlerConfiguration.getOidcConfiguration(), oidcProviderMetadata);
+        new OidcTokenValidator(oidcConfiguration, oidcProviderMetadata);
     WebContext webContext = (WebContext) oidcAuthenticationToken.getContext();
 
     oidcTokenValidator.validateAccessToken(credentials.getAccessToken(), credentials.getIdToken());
@@ -94,10 +96,7 @@ public class OidcRealm extends AuthenticatingRealm {
     } else {
       try {
         OidcAuthenticator authenticator =
-            new CustomOidcAuthenticator(
-                oidcHandlerConfiguration.getOidcConfiguration(),
-                oidcHandlerConfiguration.getOidcClient(),
-                oidcProviderMetadata);
+            new CustomOidcAuthenticator(oidcConfiguration, oidcClient, oidcProviderMetadata);
         authenticator.validate(credentials, webContext);
       } catch (TechnicalException e) {
         LOGGER.debug(
@@ -123,8 +122,7 @@ public class OidcRealm extends AuthenticatingRealm {
     }
 
     OidcProfileCreator oidcProfileCreator =
-        new CustomOidcProfileCreator(
-            oidcHandlerConfiguration.getOidcConfiguration(), oidcProviderMetadata);
+        new CustomOidcProfileCreator(oidcConfiguration, oidcProviderMetadata);
     OidcProfile profile = oidcProfileCreator.create(credentials, webContext);
 
     SimpleAuthenticationInfo simpleAuthenticationInfo = new SimpleAuthenticationInfo();

--- a/ui/packages/ui/src/main/webapp/components/installer/installer.view.js
+++ b/ui/packages/ui/src/main/webapp/components/installer/installer.view.js
@@ -135,9 +135,9 @@ define([
       this.$el.toggleClass('is-loading', false)
       var welcomeStep = 0,
         profileStep = 1,
-        ssoConfigurationStep = 2,
-        guestClaimsStep = 3,
-        configStep = 4,
+        guestClaimsStep = 2,
+        configStep = 3,
+        ssoConfigurationStep = 4,
         finishStep = 5
 
       var stepNumber = this.model.get('stepNumber')


### PR DESCRIPTION
* Swaps the SSO configuration page in the installer UI to come after the keystore config page
* Applies handler configuration even if validation fails. This allows the configuration to work even if the auth server comes online after DDF
* Fixes the issue where the handler configuration isn't persisted across restarts